### PR TITLE
Corrections in Unknown values size.

### DIFF
--- a/documentation/Windows Prefetch File (PF) format.asciidoc
+++ b/documentation/Windows Prefetch File (PF) format.asciidoc
@@ -411,13 +411,13 @@ The offset is relative to the start of the file
 | 44 | 8 x 8 = 64 | | Last run time(s) +
 Contains FILETIMEs, or 0 if not set +
 The first FILETIME is the most recent run time
-| 108 | 8 | | [yellow-background]*Unknown* +
+| *108* | *8* | | [yellow-background]*Unknown* +
 [yellow-background]*Mostly empty values but seem to get filled the run after the 8 last run times have been filled.* +
 [yellow-background]*Could be remnant values.*
-| 116 | 4 | | Run count
-| 120 | 4 | | [yellow-background]*Unknown* +
+| *116* | *4* | | *Run count*
+| *120* | *4* | | [yellow-background]*Unknown* +
 [yellow-background]*Seen: 1*
-| 124 | 4 | | [yellow-background]*Unknown* +
+| *124* | *4* | | [yellow-background]*Unknown* +
 [yellow-background]*Seen: 3*
 | *128* | *4* | | *Hash string offset* +
 The offset is relative to the start of the file

--- a/documentation/Windows Prefetch File (PF) format.asciidoc
+++ b/documentation/Windows Prefetch File (PF) format.asciidoc
@@ -419,9 +419,9 @@ The first FILETIME is the most recent run time
 [yellow-background]*Seen: 1*
 | 124 | 4 | | [yellow-background]*Unknown* +
 [yellow-background]*Seen: 3*
-| 128 | 4 | | Hash string offset +
+| *128* | *4* | | *Hash string offset* +
 The offset is relative to the start of the file
-| 132 | 4 | | Hash string size
+| *132* | *4* | | *Hash string size*
 | *136* | *76* | | [yellow-background]*Unknown (Empty values)*
 |===
 

--- a/documentation/Windows Prefetch File (PF) format.asciidoc
+++ b/documentation/Windows Prefetch File (PF) format.asciidoc
@@ -350,12 +350,12 @@ The entries with a bold offset and size were changed since version 23.
 [NOTE]
 There are multiple variants of file information - version 30
 
-* Variant 1, that is 220/228 bytes in size (depending on the presence of hash string section) and appears to be similar to the file information version 26.
+* Variant 1, that is 220/212 bytes in size (depending on the presence of hash string section) and appears to be similar to the file information version 26.
 * Variant 2, that is 212 bytes in size.
 
 ==== File information - version 30 - variant 1
 
-The file information - version 30 - variant 1 is 220/228 bytes of size and consists of:
+The file information - version 30 - variant 1 is 220/212 bytes of size and consists of:
 
 [cols="1,1,1,5",options="header"]
 |===

--- a/documentation/Windows Prefetch File (PF) format.asciidoc
+++ b/documentation/Windows Prefetch File (PF) format.asciidoc
@@ -312,7 +312,7 @@ The entries with a bold offset and size were changed since version 17.
 
 ==== File information - version 26
 
-The file information - version 26 is 224 bytes of size and consists of:
+The file information - version 26 is 220 bytes of size and consists of:
 
 [cols="1,1,1,5",options="header"]
 |===
@@ -340,7 +340,7 @@ The first FILETIME is the most recent run time
 [yellow-background]*Seen: 1, 2, 7*
 | *132* | *4* | | [yellow-background]*Unknown* +
 [yellow-background]*Seen: 0, 3*
-| *136* | *88* | | [yellow-background]*Unknown (Empty values)*
+| *136* | *84* | | [yellow-background]*Unknown (Empty values)*
 |===
 
 The entries with a bold offset and size were changed since version 23.
@@ -355,7 +355,7 @@ There are multiple variants of file information - version 30
 
 ===== File information - version 30 - variant 2
 
-The file information - version 30 - variant 2 is 224 bytes of size and consists of:
+The file information - version 30 - variant 2 is 212 bytes of size and consists of:
 
 [cols="1,1,1,5",options="header"]
 |===
@@ -383,7 +383,9 @@ The first FILETIME is the most recent run time
 [yellow-background]*Seen: 1*
 | *124* | *4* | | [yellow-background]*Unknown* +
 [yellow-background]*Seen: 3*
-| *128* | *88* | | [yellow-background]*Unknown (Empty values)*
+| *128* | *4* | | *Hash string offset*
+| *132* | *4* | | *Hash string size*
+| *136* | *76* | | [yellow-background]*Unknown (Empty values)*
 |===
 
 The entries with a bold offset and size were changed since version 26 (or

--- a/documentation/Windows Prefetch File (PF) format.asciidoc
+++ b/documentation/Windows Prefetch File (PF) format.asciidoc
@@ -350,12 +350,12 @@ The entries with a bold offset and size were changed since version 23.
 [NOTE]
 There are multiple variants of file information - version 30
 
-* Variant 1, that is 220/212 bytes in size (depending on the presence of hash string section) and appears to be similar to the file information version 26.
+* Variant 1, that is 220 bytes in size (depending on the presence of hash string section) and appears to be similar to the file information version 26.
 * Variant 2, that is 212 bytes in size.
 
 ==== File information - version 30 - variant 1
 
-The file information - version 30 - variant 1 is 220/212 bytes of size and consists of:
+The file information - version 30 - variant 1 is 220 bytes of size and consists of:
 
 [cols="1,1,1,5",options="header"]
 |===

--- a/documentation/Windows Prefetch File (PF) format.asciidoc
+++ b/documentation/Windows Prefetch File (PF) format.asciidoc
@@ -350,7 +350,7 @@ The entries with a bold offset and size were changed since version 23.
 
 There are multiple variants of file information - version 30
 
-* Variant 1, that is 220 bytes in size (depending on the presence of hash string section) and appears to be similar to the file information version 26.
+* Variant 1, that is 220 bytes in size.
 * Variant 2, that is 212 bytes in size.
 
 ==== File information - version 30 - variant 1

--- a/documentation/Windows Prefetch File (PF) format.asciidoc
+++ b/documentation/Windows Prefetch File (PF) format.asciidoc
@@ -350,8 +350,46 @@ The entries with a bold offset and size were changed since version 23.
 [NOTE]
 There are multiple variants of file information - version 30
 
-* Variant 1, that is 224 bytes in size and appears to be similar to the file information version 26.
-* Variant 2, that is 216 bytes in size.
+* Variant 1, that is 220 bytes in size and appears to be similar to the file information version 26.
+* Variant 2, that is 212 bytes in size.
+
+==== File information - version 30 - variant 1
+
+The file information - version 30 - variant 1 is 220 bytes of size and consists of:
+
+[cols="1,1,1,5",options="header"]
+|===
+| Offset | Size | Value | Description
+| 0 | 4 | 304 (0x00000130) | File metrics array offset +
+The offset is relative to the start of the file
+| 4 | 4 | | Number of file metrics entries
+| 8 | 4 | | Trace chains array offset +
+The offset is relative to the start of the file
+| 12 | 4 | | Number of trace chains array entries
+| 16 | 4 | | Filename strings offset
+| 20 | 4 | | Filename strings size
+| 24 | 4 | | Volumes information offset
+| 28 | 4 | | Number of volumes
+| 32 | 4 | | Volumes information size
+| 36 | 8 | | [yellow-background]*Unknown (Empty values)*
+| 44 | *8 x 8 = 64* | | Last run time(s) +
+Contains FILETIMEs, or 0 if not set +
+The first FILETIME is the most recent run time
+| *108* | *16* | | [yellow-background]*Unknown* +
+[yellow-background]*Mostly empty values but seem to get filled the run after the 8 last run times have been filled.* +
+[yellow-background]*Could be remnant values.*
+| 124 | 4 | | Run count
+| *128* | *4* | | [yellow-background]*Unknown* +
+[yellow-background]*Seen: 1, 2, 7*
+| *132* | *4* | | [yellow-background]*Unknown* +
+[yellow-background]*Seen: 0, 3*
+| *136* | *4* | | *Hash string offset*
+| *140* | *4* | | *Hash string size*
+| *144* | *76* | | [yellow-background]*Unknown (Empty values)*
+|===
+
+[NOTE]
+The Hash string offset and Hash string size are observed in some prefetch files whereas some don't have them.
 
 ===== File information - version 30 - variant 2
 
@@ -387,6 +425,9 @@ The first FILETIME is the most recent run time
 | *132* | *4* | | *Hash string size*
 | *136* | *76* | | [yellow-background]*Unknown (Empty values)*
 |===
+
+[NOTE]
+The Hash string offset and Hash string size are observed in all prefetch files in variant 2.
 
 The entries with a bold offset and size were changed since version 26 (or
 30 - variant 1).

--- a/documentation/Windows Prefetch File (PF) format.asciidoc
+++ b/documentation/Windows Prefetch File (PF) format.asciidoc
@@ -350,12 +350,12 @@ The entries with a bold offset and size were changed since version 23.
 [NOTE]
 There are multiple variants of file information - version 30
 
-* Variant 1, that is 220 bytes in size and appears to be similar to the file information version 26.
+* Variant 1, that is 220/224 bytes in size (depending on the presence of hash string section) and appears to be similar to the file information version 26.
 * Variant 2, that is 212 bytes in size.
 
 ==== File information - version 30 - variant 1
 
-The file information - version 30 - variant 1 is 220 bytes of size and consists of:
+The file information - version 30 - variant 1 is 220/224 bytes of size and consists of:
 
 [cols="1,1,1,5",options="header"]
 |===

--- a/documentation/Windows Prefetch File (PF) format.asciidoc
+++ b/documentation/Windows Prefetch File (PF) format.asciidoc
@@ -31,7 +31,7 @@ for the libscca project.
 == License
 
 ....
-Copyright (C) 2011-2020, Joachim Metz <joachim.metz@gmail.com>.
+Copyright (C) 2011-2023, Joachim Metz <joachim.metz@gmail.com>.
 Permission is granted to copy, distribute and/or modify this document under the
 terms of the GNU Free Documentation License, Version 1.3 or any later version
 published by the Free Software Foundation; with no Invariant Sections, no
@@ -64,6 +64,7 @@ in the section entitled "GNU Free Documentation License".
 | 0.0.17 | J.B. Metz | June 2019 | Additional information regarding Windows 10 1903 v30 variant 2.
 | 0.0.18 | J.B. Metz | February 2020 | Cleaned up notes.
 | 0.0.19 | J.B. Metz | September 2020 | Cleaned up notes.
+| 0.0.20 | N. Suthar | July 2023 | Corrections and additional information regarding unknown "hash string" section.
 |===
 
 :numbered:
@@ -347,7 +348,6 @@ The entries with a bold offset and size were changed since version 23.
 
 ==== File information - version 30
 
-[NOTE]
 There are multiple variants of file information - version 30
 
 * Variant 1, that is 220 bytes in size (depending on the presence of hash string section) and appears to be similar to the file information version 26.
@@ -372,24 +372,22 @@ The offset is relative to the start of the file
 | 28 | 4 | | Number of volumes
 | 32 | 4 | | Volumes information size
 | 36 | 8 | | [yellow-background]*Unknown (Empty values)*
-| 44 | *8 x 8 = 64* | | Last run time(s) +
+| 44 | 8 x 8 = 64 | | Last run time(s) +
 Contains FILETIMEs, or 0 if not set +
 The first FILETIME is the most recent run time
-| *108* | *16* | | [yellow-background]*Unknown* +
+| 108 | 16 | | [yellow-background]*Unknown* +
 [yellow-background]*Mostly empty values but seem to get filled the run after the 8 last run times have been filled.* +
 [yellow-background]*Could be remnant values.*
 | 124 | 4 | | Run count
-| *128* | *4* | | [yellow-background]*Unknown* +
-[yellow-background]*Seen: 1, 2, 7*
-| *132* | *4* | | [yellow-background]*Unknown* +
-[yellow-background]*Seen: 0, 3*
-| *136* | *4* | | *Hash string offset*
+| 128 | 4 | | [yellow-background]*Unknown*
+| 132 | 4 | | [yellow-background]*Unknown*
+| *136* | *4* | | *Hash string offset* +
+The offset is relative to the start of the file
 | *140* | *4* | | *Hash string size*
 | *144* | *76* | | [yellow-background]*Unknown (Empty values)*
 |===
 
-[NOTE]
-The Hash string offset and Hash string size are observed in some prefetch files whereas some don't have them.
+The entries with a bold offset and size were changed since version 26.
 
 ===== File information - version 30 - variant 2
 
@@ -410,27 +408,24 @@ The offset is relative to the start of the file
 | 28 | 4 | | Number of volumes
 | 32 | 4 | | Volumes information size
 | 36 | 8 | | [yellow-background]*Unknown (Empty values)*
-| 44 | *8 x 8 = 64* | | Last run time(s) +
+| 44 | 8 x 8 = 64 | | Last run time(s) +
 Contains FILETIMEs, or 0 if not set +
 The first FILETIME is the most recent run time
-| *108* | *8* | | [yellow-background]*Unknown* +
+| 108 | 8 | | [yellow-background]*Unknown* +
 [yellow-background]*Mostly empty values but seem to get filled the run after the 8 last run times have been filled.* +
 [yellow-background]*Could be remnant values.*
 | 116 | 4 | | Run count
-| *120* | *4* | | [yellow-background]*Unknown* +
+| 120 | 4 | | [yellow-background]*Unknown* +
 [yellow-background]*Seen: 1*
-| *124* | *4* | | [yellow-background]*Unknown* +
+| 124 | 4 | | [yellow-background]*Unknown* +
 [yellow-background]*Seen: 3*
-| *128* | *4* | | *Hash string offset*
-| *132* | *4* | | *Hash string size*
+| 128 | 4 | | Hash string offset +
+The offset is relative to the start of the file
+| 132 | 4 | | Hash string size
 | *136* | *76* | | [yellow-background]*Unknown (Empty values)*
 |===
 
-[NOTE]
-The Hash string offset and Hash string size are observed in all prefetch files in variant 2.
-
-The entries with a bold offset and size were changed since version 26 (or
-30 - variant 1).
+The entries with a bold offset and size were changed since version 30 - variant 1.
 
 === File metrics array
 

--- a/documentation/Windows Prefetch File (PF) format.asciidoc
+++ b/documentation/Windows Prefetch File (PF) format.asciidoc
@@ -350,12 +350,12 @@ The entries with a bold offset and size were changed since version 23.
 [NOTE]
 There are multiple variants of file information - version 30
 
-* Variant 1, that is 220/224 bytes in size (depending on the presence of hash string section) and appears to be similar to the file information version 26.
+* Variant 1, that is 220/228 bytes in size (depending on the presence of hash string section) and appears to be similar to the file information version 26.
 * Variant 2, that is 212 bytes in size.
 
 ==== File information - version 30 - variant 1
 
-The file information - version 30 - variant 1 is 220/224 bytes of size and consists of:
+The file information - version 30 - variant 1 is 220/228 bytes of size and consists of:
 
 [cols="1,1,1,5",options="header"]
 |===


### PR DESCRIPTION
* Made corrections for unknown values size for PFV 30, Variants 1 (Version 26) and 2.
* Document the new section found from WIP research as 'Hash string' as prefetch hash is computed using:
> 1) This string only, for normal prefetch files.
> 2) This string + a variable combination of (/prefetch: flag, command line arguments), for application hosting prefetch files.

Note to self:
Confirm/discard absence of the `Hash string` section in PFV 30, Variant 1.